### PR TITLE
Fix: force refresh for embedding and hypernetwork tables initialization

### DIFF
--- a/extensions-builtin/sd-webui-ux/scripts/anapnoe/database_manager.py
+++ b/extensions-builtin/sd-webui-ux/scripts/anapnoe/database_manager.py
@@ -94,8 +94,13 @@ class DatabaseManager:
                 "message": "No valid table types to process"
             }) + "\n"
             return
-            
+
+        if refresh:
+            for page in pages.values():
+                page.refresh()
+
         total_items = sum(len(list(page.list_items()) or []) for page in pages.values())
+
         
         pbar = tqdm(total=total_items, unit='item', 
                     bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt} [{percentage:3.0f}%]')

--- a/extensions-builtin/sd-webui-ux/scripts/anapnoe_sd_uiux_db.py
+++ b/extensions-builtin/sd-webui-ux/scripts/anapnoe_sd_uiux_db.py
@@ -78,9 +78,10 @@ def initialize_tables():
     else:
         logger.debug("All tables already exist in database")
 
-initialize_tables()
-
 def on_ui_tabs():
+    # Make sure tables are initialized when UI loads
+    initialize_tables()
+
     with gr.Blocks(analytics_enabled=False) as anapnoe_sd_uiux_db:
         refresh_button = gr.Button("Refresh Database", elem_id="refresh_database")
         refresh_button.click(fn=initialize_tables, inputs=[], outputs=[])
@@ -88,3 +89,4 @@ def on_ui_tabs():
     return (anapnoe_sd_uiux_db, 'Init DB', 'anapnoe_sd_uiux_db'),
 
 script_callbacks.on_ui_tabs(on_ui_tabs)
+


### PR DESCRIPTION
This PR addresses an issue where the textualinversion and hypernetwork tables were not being created or refreshed in the database, resulting in errors such as:

ERROR:anapnoe.database_manager:Database error: no such table: textualinversion
ERROR:anapnoe.database_manager:Database error: no such table: hypernetwork


Changes made:

Added page.refresh() in import_tables_generator to ensure tables are refreshed before checking items.

Ensured initialization is properly triggered inside on_ui_tabs() so tables are created at startup.

Result:
Embeddings and Hypernetworks are now detected correctly in the UI and database tables are initialized as expected.